### PR TITLE
Update Ethereal to Wireshark

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ For more detailed installation instructions, see the
       <a href="http://www.gnome.org">GNOME</a> (via 
       <a href="http://www.gnome.org/~jdub/garnome/">GARNOME</a>),
       <a href="http://www.samba.org/">Samba</a> and 
-      <a href="http://www.ethereal.com/">Ethereal</a>.  
+      <a href="https://www.wireshark.org/">Wireshark</a>.  
 
      <p>
       distcc is nearly linearly scalable for small numbers of


### PR DESCRIPTION
[Ethereal has been renamed to Wireshark quite some time ago](https://www.wireshark.org/faq.html#_whats_up_with_the_name_change_is_wireshark_a_fork). The old Ethereal website seems to be down.

Note: I did not check if Wireshark can actually be built with distcc. A better option might be to just remove Ethereal form the list of known working projects.